### PR TITLE
Add license header and NOTICE checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: write-all
-
 defaults:
   run:
     working-directory: ./
@@ -49,6 +47,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: ./.github/actions/python_build
         with:
           tags: "[cicd]"
@@ -63,6 +62,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: ./.github/actions/python_build
         with:
           tags: "[cicd]"
@@ -77,6 +77,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: ./.github/actions/python_build
         with:
           tags: "[cicd]"
@@ -88,9 +89,14 @@ jobs:
   pytest_and_mkdocs:
     name: Run pytest with coverage and mkdocs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: ./.github/actions/python_build
         with:
           tags: "[cicd,docs]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
         run: |
           black --config pyproject.toml --check .
 
-  pytest_and_mkdocs:
-    name: Run pytest with coverage and mkdocs
+  pytest:
+    name: Run pytest and generate coverage reports
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -99,7 +99,7 @@ jobs:
 
       - uses: ./.github/actions/python_build
         with:
-          tags: "[cicd,docs]"
+          tags: "[cicd]"
 
       - name: Run pytest with coverage
         run: |
@@ -113,10 +113,3 @@ jobs:
         with:
           pytest-xml-coverage-path: ./reports/coverage.xml
           junitxml-path: ./reports/test-results-${{ env.PYTHON_VERSION }}.xml
-
-      - name: Deploy documentation to GitHub Pages
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-        run: |
-          coverage html -d ./reports/htmlcov
-          genbadge coverage -i ./reports/coverage.xml -o ./reports/htmlcov/coverage-badge.svg
-          mkdocs gh-deploy --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,18 @@ env:
   PYTHON_VERSION: "3.9"
 
 jobs:
+  license_check:
+    name: Check missing license headers
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check license header
+        uses: apache/skywalking-eyes/header@v0.6.0
+        with:
+          config: .licenserc.yml
+
   pylint:
     runs-on: ubuntu-latest
 
@@ -73,7 +85,8 @@ jobs:
         run: |
           black --config pyproject.toml --check .
 
-  pytest_and_docs:
+  pytest_and_mkdocs:
+    name: Run pytest with coverage and mkdocs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/notice.yml
+++ b/.github/workflows/notice.yml
@@ -1,0 +1,37 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Update NOTICE copyright year at the start of every year"
+
+on:
+  schedule:
+    - cron:  '15 15 1 1 *'
+
+jobs:
+  notice_update:
+    name: Update NOTICE copyright year
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update NOTICE file
+        run: |
+          sed -i "s/$(date +%Y --date='1 year ago')/$(date +%Y)/" NOTICE
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          add: 'NOTICE'
+          message: 'Update NOTICE copyright year'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,30 @@ env:
   PYTHON_VERSION: "3.9"
 
 jobs:
+  mkdocs:
+    name: Deploy documentation to GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/python_build
+        with:
+          tags: "[cicd,docs]"
+
+      - name: Generate coverage report
+        run: |
+          coverage run -m pytest
+          coverage html -d ./reports/htmlcov
+          coverage xml -o ./reports/coverage.xml
+          genbadge coverage -i ./reports/coverage.xml -o ./reports/htmlcov/coverage-badge.svg
+
+      - name: Run mkdocs
+        run: |
+          mkdocs gh-deploy --force
+
   pypi-publish:
     name: Publish release to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: ./.github/actions/python_build
         with:
             tags: "[build]"

--- a/.licenserc.yml
+++ b/.licenserc.yml
@@ -1,0 +1,26 @@
+header:
+  license:
+    content: |
+      See the NOTICE file distributed with this work for additional information
+      regarding copyright ownership.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+  paths-ignore:
+    - '**/*.md'
+    - 'tests/**/test_*/*'
+    - '.gitignore'
+    - 'LICENSE'
+    - 'NOTICE'
+
+  comment: on-failure

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,19 @@
+/* See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 [data-md-color-scheme="ensembl"] {
   --md-primary-fg-color:        #1b2c39;
   --md-primary-bg-color:        hsla(0, 0%, 100%, 1);


### PR DESCRIPTION
I have gone one step further with the NOTICE check and made it an automatic NOTICE copyright year update pipeline run automatically on the 1st January of each year.

License checks has detected one file missing the header, so it has been added.

I have also taken the opportunity to refine the job permissions to limit their effect and move the documentation generation to the `publish` pipeline, as it makes more sense for the GitHub pages to be in sync with a release.