### PR TITLE
Add param reflect to avoid loading tables

### DIFF
--- a/src/ensembl/utils/database/dbconnection.py
+++ b/src/ensembl/utils/database/dbconnection.py
@@ -54,12 +54,15 @@ class DBConnection:
 
     Args:
         url: URL to the database, e.g. `mysql://user:passwd@host:port/my_db`.
+        reflect: Reflect the database schema or not.
 
     """
 
-    def __init__(self, url: StrURL, **kwargs) -> None:
+    def __init__(self, url: StrURL, reflect: bool = True, **kwargs) -> None:
         self._engine = create_engine(url, future=True, **kwargs)
-        self.load_metadata()
+        self._metadata = None
+        if reflect:
+            self.load_metadata()
 
     def __repr__(self) -> str:
         """Returns a string representation of this object."""
@@ -99,7 +102,9 @@ class DBConnection:
     @property
     def tables(self) -> dict[str, sqlalchemy.schema.Table]:
         """Returns the database tables keyed to their name."""
-        return self._metadata.tables
+        if self._metadata:
+            return self._metadata.tables
+        return {}
 
     def get_primary_key_columns(self, table: str) -> list[str]:
         """Returns the primary key column names for the given table.

--- a/tests/database/test_dbconnection.py
+++ b/tests/database/test_dbconnection.py
@@ -16,6 +16,7 @@
 
 from contextlib import nullcontext as does_not_raise
 import os
+from pathlib import Path
 from typing import ContextManager
 
 import pytest
@@ -232,3 +233,21 @@ class TestDBConnection:
             assert len(results.all()) == 2, f"SQLite/MyISAM: 2 rows permanently added to ID {identifier}"
         else:
             assert not results.fetchall(), f"No entries should have been permanently added to ID {identifier}"
+
+
+@pytest.mark.parametrize(
+    "reflect, tables",
+    [
+        param(True, set(["gibberish"]), id="With reflection"),
+        param(False, set(), id="No reflection"),
+    ],
+)
+def test_reflect(tmp_path: Path, data_dir: Path, reflect: bool, tables: set) -> None:
+    """Tests the object `DBConnection` with and without reflection."""
+
+    # Create a test db
+    db_url = make_url(f"sqlite://{tmp_path}")
+    test_db = UnitTestDB(db_url, data_dir / "mock_db")
+    test_db_url = test_db.dbc.url
+    con = DBConnection(test_db_url, reflect=reflect)
+    assert set(con.tables.keys()) == tables


### PR DESCRIPTION
Default remains to load the metadata.

Avoiding the reflection allows for faster access to the connection if we don't need to infer the schema from the database.