### PR TITLE
Coverage report will usually fail for PRs from forks

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -103,6 +103,7 @@ jobs:
 
       - name: Add coverage reports
         if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-xml-coverage-path: ./reports/coverage.xml


### PR DESCRIPTION
There may be a better fix to actually get a coverage report every time, but this resolves the pipeline failing even when `pytest` has run successfully, which may be good enough for now.