### PR TITLE
Rework to allow use of metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+    "mysqlclient",
     "pytest >= 8.2.0",
     "python-dotenv >= 0.19.2",
     "pyyaml ~= 6.0",

--- a/src/ensembl/utils/database/dbconnection.py
+++ b/src/ensembl/utils/database/dbconnection.py
@@ -43,6 +43,7 @@ from typing import ContextManager, Generator, Optional, TypeVar
 import sqlalchemy
 from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.schema import MetaData, Table
 
 
 Query = TypeVar("Query", str, sqlalchemy.sql.expression.ClauseElement, sqlalchemy.sql.expression.TextClause)
@@ -73,6 +74,17 @@ class DBConnection:
         # Note: Just reflect() is not enough as it would not delete tables that no longer exist
         self._metadata = sqlalchemy.MetaData()
         self._metadata.reflect(bind=self._engine)
+    
+    def create_all_tables(self, metadata: MetaData) -> None:
+        """Create the tables from the metadata and set the metadata."""
+        self._metadata = metadata
+        metadata.create_all(self._engine)
+    
+    def create_table(self, table: Table) -> None:
+        """Create a table in the database and update the metadata."""
+        table.create(self._engine)
+        # We need to update the metadata to register the new table
+        self.load_metadata()
 
     @property
     def url(self) -> str:

--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 __all__ = [
     "UnitTestDB",
+    "UnitTestDBGenerator",
 ]
 
 import os
@@ -151,3 +152,16 @@ class UnitTestDB:
             conn.execute(text(f"BULK INSERT {table} FROM '{src}'"))
         else:
             conn.execute(text(f"LOAD DATA LOCAL INFILE '{src}' INTO TABLE {table}"))
+
+
+class UnitTestDBGenerator:
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self):
+        self.test_db = UnitTestDB(*self.args, **self.kwargs)
+        return self.test_db
+    
+    def __exit__(self, *args):
+        self.test_db.drop()

--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -67,7 +67,7 @@ class UnitTestDB:
 
     """
 
-    def __init__(self, server_url: StrURL, dump_dir: StrPath | None = None, name: str | None = None, metadata: MetaData | None = None) -> None:
+    def __init__(self, server_url: StrURL, dump_dir: StrPath | None = None, name: str | None = None, metadata: MetaData | None = None, tmp_path: Path | None = None) -> None:
         db_url = make_url(server_url)
         if not name:
             name = Path(dump_dir).name if dump_dir else "testdb"
@@ -75,7 +75,8 @@ class UnitTestDB:
 
         # Add the database name to the URL
         if db_url.get_dialect().name == "sqlite":
-            db_url = db_url.set(database=f"{db_name}.db")
+            db_path = tmp_path / db_name if tmp_path else db_name
+            db_url = db_url.set(database=f"{db_path}.db")
         else:
             db_url = db_url.set(database=db_name)
 

--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -20,9 +20,14 @@ preexisting dumps (if supplied).
 Examples:
 
     >>> from ensembl.utils.database import UnitTestDB
+    >>> # For more safety use the context manager (automatically drops the database even if things go wrong):
+    >>> with UnitTestDB("mysql://user:passwd@mysql-server:4242/", "path/to/dumps", "my_db") as test_db:
+    >>>    dbc = test_db.dbc
+
+    >>> # If you know what you are doing you can also control when the testdb is dropped:
     >>> test_db = UnitTestDB("mysql://user:passwd@mysql-server:4242/", "path/to/dumps", "my_db")
     >>> # You can access the database via test_db.dbc, for instance:
-    >>> results = test_db.dbc.execute("SELECT * FROM my_table;")
+    >>> dbc = test_db.dbc
     >>> # At the end do not forget to drop the database
     >>> test_db.drop()
 
@@ -155,6 +160,7 @@ class UnitTestDB:
 
 
 class UnitTestDBContext:
+    """Context manager that returns a `UnitTestDB` when using `with`, and drops it afterwards."""
     def __init__(self, *args, **kwargs) -> None:
         self.args = args
         self.kwargs = kwargs

--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 __all__ = [
     "UnitTestDB",
-    "UnitTestDBGenerator",
+    "UnitTestDBContext",
 ]
 
 import os
@@ -154,7 +154,7 @@ class UnitTestDB:
             conn.execute(text(f"LOAD DATA LOCAL INFILE '{src}' INTO TABLE {table}"))
 
 
-class UnitTestDBGenerator:
+class UnitTestDBContext:
     def __init__(self, *args, **kwargs) -> None:
         self.args = args
         self.kwargs = kwargs

--- a/src/ensembl/utils/plugin.py
+++ b/src/ensembl/utils/plugin.py
@@ -137,7 +137,7 @@ def fixture_db_factory(request: FixtureRequest, data_dir: Path) -> Generator[Cal
         if not src_path.is_absolute():
             src_path = data_dir / src_path
         db_key = name if name else src_path.name
-        return created.setdefault(db_key, UnitTestDB(server_url, src_path, name))
+        return created.setdefault(db_key, UnitTestDB(server_url, dump_dir=src_path, name=name))
 
     yield _db_factory
     # Drop all unit test databases unless the user has requested to keep them
@@ -170,5 +170,5 @@ def test_dbs(request: FixtureRequest, db_factory: Callable) -> dict[str, UnitTes
         src = Path(argument["src"])
         name = argument.get("name", None)
         key = name if name else src.name
-        databases[key] = db_factory(src, name)
+        databases[key] = db_factory(src=src, name=name)
     return databases

--- a/tests/database/test_dbconnection.py
+++ b/tests/database/test_dbconnection.py
@@ -263,7 +263,7 @@ def test_reflect(tmp_path: Path, data_dir: Path, reflect: bool, tables: set) -> 
 
     # Create a test db
     server_url = make_url(f"sqlite:///{tmp_path}")
-    test_db = UnitTestDB(server_url, data_dir / "mock_db")
+    test_db = UnitTestDB(server_url, dump_dir=data_dir / "mock_db")
     test_db_url = test_db.dbc.url
     con = DBConnection(test_db_url, reflect=reflect)
     assert set(con.tables.keys()) == tables

--- a/tests/database/test_dbconnection.py
+++ b/tests/database/test_dbconnection.py
@@ -27,7 +27,7 @@ from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.schema import Table
-from sqlalchemy_utils import create_database, drop_database
+from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from ensembl.utils.database import DBConnection, Query, UnitTestDB
 
@@ -287,7 +287,8 @@ def test_create_all_tables(request: FixtureRequest, tmp_path: Path) -> None:
     db_url = make_url(request.config.getoption("server"))
     db_name = f"{os.environ['USER']}_test_create_all_tables"
     db_url = db_url.set(database=db_name)
-    drop_database(db_url)
+    if database_exists(db_url):
+        drop_database(db_url)
     create_database(db_url)
 
     try:
@@ -306,7 +307,8 @@ def test_create_table(request: FixtureRequest, tmp_path: Path) -> None:
     db_url = make_url(request.config.getoption("server"))
     db_name = f"{os.environ['USER']}_test_create_table"
     db_url = db_url.set(database=db_name)
-    drop_database(db_url)
+    if database_exists(db_url):
+        drop_database(db_url)
     create_database(db_url)
 
     try:

--- a/tests/database/test_dbconnection.py
+++ b/tests/database/test_dbconnection.py
@@ -27,7 +27,7 @@ from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.schema import Table
-from sqlalchemy_utils import create_database
+from sqlalchemy_utils import create_database, drop_database
 
 from ensembl.utils.database import DBConnection, Query, UnitTestDB
 
@@ -285,13 +285,18 @@ def test_create_all_tables(request: FixtureRequest, tmp_path: Path) -> None:
 
     # Create a test db
     db_url = make_url(request.config.getoption("server"))
-    db_name = os.environ["USER"] + "_" + "test_create_all_tables"
-    db_url.set(database=db_name)
+    db_name = f"{os.environ['USER']}_test_create_all_tables"
+    db_url = db_url.set(database=db_name)
+    drop_database(db_url)
     create_database(db_url)
 
-    test_db = DBConnection(db_url, reflect=False)
-    test_db.create_all_tables(mock_metadata)
-    assert set(test_db.tables.keys()) == set(mock_metadata.tables.keys())
+    try:
+        test_db = DBConnection(db_url, reflect=False)
+        test_db.create_all_tables(mock_metadata)
+        assert set(test_db.tables.keys()) == set(mock_metadata.tables.keys())
+    except:
+        pass
+    drop_database(db_url)
 
 
 def test_create_table(request: FixtureRequest, tmp_path: Path) -> None:
@@ -299,10 +304,15 @@ def test_create_table(request: FixtureRequest, tmp_path: Path) -> None:
 
     # Create a test db
     db_url = make_url(request.config.getoption("server"))
-    db_name = os.environ["USER"] + "_" + "test_create_table"
-    db_url.set(database=db_name)
+    db_name = f"{os.environ['USER']}_test_create_table"
+    db_url = db_url.set(database=db_name)
+    drop_database(db_url)
     create_database(db_url)
 
-    test_db = DBConnection(db_url, reflect=False)
-    test_db.create_table(mock_metadata.tables["mock_table"])
-    assert set(test_db.tables.keys()) == set(["mock_table"])
+    try:
+        test_db = DBConnection(db_url, reflect=False)
+        test_db.create_table(mock_metadata.tables["mock_table"])
+        assert set(test_db.tables.keys()) == set(["mock_table"])
+    except:
+        pass
+    drop_database(db_url)

--- a/tests/database/test_unittestdb.py
+++ b/tests/database/test_unittestdb.py
@@ -20,7 +20,7 @@ from typing import ContextManager, Optional
 
 import pytest
 from pytest import FixtureRequest, param, raises
-from sqlalchemy import VARCHAR
+from sqlalchemy import VARCHAR, text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.schema import MetaData
 from sqlalchemy_utils.functions import database_exists
@@ -88,8 +88,10 @@ class TestUnitTestDB:
                 assert db, "UnitTestDB should not be empty"
                 assert db.dbc, "UnitTestDB's database connection should not be empty"
                 # Check that the database has been loaded correctly from the dump files
-                result = db.dbc.execute("SELECT * FROM gibberish")
-                assert len(result.fetchall()) == 6, "Unexpected number of rows found in 'gibberish' table"
+
+                with db.dbc.test_session_scope() as session:
+                    result = session.execute(text("SELECT * FROM gibberish"))
+                    assert len(result.fetchall()) == 6, "Unexpected number of rows found in 'gibberish' table"
 
         @pytest.mark.parametrize(
             "metadata, tables",

--- a/tests/database/test_unittestdb.py
+++ b/tests/database/test_unittestdb.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.schema import MetaData
 from sqlalchemy_utils.functions import database_exists
 
-from ensembl.utils.database import UnitTestDB, UnitTestDBGenerator
+from ensembl.utils.database import UnitTestDB, UnitTestDBContext
 
 
 class MockBase(DeclarativeBase):
@@ -83,7 +83,7 @@ class TestUnitTestDB:
         with expectation:
             server_url = request.config.getoption("server")
             src_path = src if src.is_absolute() else data_dir / src
-            with UnitTestDBGenerator(server_url, dump_dir=src_path, name=name, tmp_path=tmp_path) as db:
+            with UnitTestDBContext(server_url, dump_dir=src_path, name=name, tmp_path=tmp_path) as db:
                 # Check that the database has been created correctly
                 assert db, "UnitTestDB should not be empty"
                 assert db.dbc, "UnitTestDB's database connection should not be empty"
@@ -118,7 +118,7 @@ class TestUnitTestDB:
 
             """
             server_url = request.config.getoption("server")
-            with UnitTestDBGenerator(server_url, metadata=metadata, tmp_path=tmp_path, name="test_metadata") as db:
+            with UnitTestDBContext(server_url, metadata=metadata, tmp_path=tmp_path, name="test_metadata") as db:
                 assert db, "UnitTestDB should not be empty"
                 assert db.dbc, "UnitTestDB's database connection should not be empty"
                 assert set(db.dbc.tables.keys()) == set(tables), "Loaded tables as expected"

--- a/tests/database/test_unittestdb.py
+++ b/tests/database/test_unittestdb.py
@@ -20,9 +20,24 @@ from typing import ContextManager, Optional
 
 import pytest
 from pytest import FixtureRequest, param, raises
+from sqlalchemy import VARCHAR
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy_utils.functions import database_exists
 
 from ensembl.utils.database import UnitTestDB
+
+
+class MockBase(DeclarativeBase):
+    pass
+
+
+class MockTable(MockBase):
+    __tablename__ = "mock_table"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    grp: Mapped[str] = mapped_column(VARCHAR(30))
+    value: Mapped[int]
+
+mock_metadata = MockBase.metadata
 
 
 class TestUnitTestDB:
@@ -94,3 +109,33 @@ class TestUnitTestDB:
         assert database_exists(db_url)
         self.dbs[db_key].drop()
         assert not database_exists(db_url)
+
+
+    @pytest.mark.parametrize(
+        "metadata, tables",
+        [
+            param(None, [], id="Create database without schema"),
+            param(mock_metadata, ["mock_table"], id="Create database from mock_metadata"),
+        ],
+    )
+    def test_metadata(
+        self,
+        request: FixtureRequest,
+        tables: list,
+        metadata: Path,
+    ) -> None:
+        """Tests that the object `UnitTestDB` is initialised correctly.
+
+        Args:
+            request: Fixture that provides information of the requesting test function.
+            data_dir: Fixture that provides the path to the test data folder matching the test's name.
+            src: Directory path with the database schema and one TSV data file per table.
+            name: Name to give to the new database.
+            expectation: Context manager for the expected exception.
+
+        """
+        server_url = request.config.getoption("server")
+        db = UnitTestDB(server_url, metadata=metadata)
+        assert db, "UnitTestDB should not be empty"
+        assert db.dbc, "UnitTestDB's database connection should not be empty"
+        assert set(db.dbc.tables.keys()) == set(tables), "Loaded tables as expected"

--- a/tests/database/test_unittestdb.py
+++ b/tests/database/test_unittestdb.py
@@ -83,7 +83,7 @@ class TestUnitTestDB:
             assert len(result.fetchall()) == 6, "Unexpected number of rows found in 'gibberish' table"
 
 
-    def test_drop(self, request: FixtureRequest) -> None:
+    def test_drop(self, request: FixtureRequest, tmp_path: Path) -> None:
         """Tests the `UnitTestDB.drop()` method.
 
         Args:
@@ -91,7 +91,7 @@ class TestUnitTestDB:
 
         """
         server_url = request.config.getoption("server")
-        db = UnitTestDB(server_url)
+        db = UnitTestDB(server_url, tmp_path=tmp_path)
         db_url = db.dbc.url
         assert database_exists(db_url)
         db.drop()
@@ -108,6 +108,7 @@ class TestUnitTestDB:
     def test_metadata(
         self,
         request: FixtureRequest,
+        tmp_path: Path,
         tables: list,
         metadata: Path,
     ) -> None:
@@ -122,7 +123,7 @@ class TestUnitTestDB:
 
         """
         server_url = request.config.getoption("server")
-        db = UnitTestDB(server_url, metadata=metadata)
+        db = UnitTestDB(server_url, metadata=metadata, tmp_path=tmp_path)
         assert db, "UnitTestDB should not be empty"
         assert db.dbc, "UnitTestDB's database connection should not be empty"
         assert set(db.dbc.tables.keys()) == set(tables), "Loaded tables as expected"

--- a/tests/database/test_unittestdb.py
+++ b/tests/database/test_unittestdb.py
@@ -56,6 +56,7 @@ class TestUnitTestDB:
         self,
         request: FixtureRequest,
         data_dir: Path,
+        tmp_path: Path,
         src: Path,
         name: Optional[str],
         expectation: ContextManager,
@@ -73,7 +74,7 @@ class TestUnitTestDB:
         with expectation:
             server_url = request.config.getoption("server")
             src_path = src if src.is_absolute() else data_dir / src
-            db = UnitTestDB(server_url, dump_dir=src_path, name=name)
+            db = UnitTestDB(server_url, dump_dir=src_path, name=name, tmp_path=tmp_path)
             # Check that the database has been created correctly
             assert db, "UnitTestDB should not be empty"
             assert db.dbc, "UnitTestDB's database connection should not be empty"


### PR DESCRIPTION
Maybe too many things changed, but I needed those to ensure I can use a metadata with :
- `DBConnection` can now be created without a schema (`dump_dir` no longer mandatory)
- `DBConnection` accepts an `Metadata` object instead of relying on an SQL file and a reflection
- Add 2 methods to `DBConnection`: `create_all_tables` and `create_table` (requires the metadata to be set as above)
- If both a `dump_dir` and a `metadata` are provided to a `UnitTestDB`, the schema is made from the `metadata` and the data is loaded from the `dump_dir` 
- Add a context manager to properly dispose of the `UnitTestDB` (`UnitTestDBContext`)

Tests:
- Add a simple mock base and mock_metadata
- When possible, use a context `session_scope` or `test_session_scope` to avoid hanging connections (unless we are specifically testing for that)
- Both SQLalchemy and MySQL should work
- Add an argument `tmp_path` to the `UnitTestDB` when asked to create an SQLite database test file

Usage:
Say you want to test interactions with a whole schema described in a given metadata. You can do so with:
```
with UnitTestDBContext(server_url, metadata=metadata, tmp_path=tmp_path, name="test_metadata") as test_db:
    with test.db.dbc.test_session_scope() as session:
        results = session.execute(text("SELECT * FROM foo"))
```
The first context ensures the database is properly disposed of no matter what, and the second ensures the changes are rolledback and the connection returned.
