### PR TITLE
Mbarba/no username

### DIFF
--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -86,7 +86,7 @@ class UnitTestDB:
         db_url = make_url(server_url)
         if not name:
             name = Path(dump_dir).name if dump_dir else "testdb"
-        db_name =  f"{TEST_USERNAME}_{name}"
+        db_name = f"{TEST_USERNAME}_{name}"
 
         # Add the database name to the URL
         if db_url.get_dialect().name == "sqlite":

--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -52,6 +52,8 @@ from sqlalchemy_utils.functions import create_database, database_exists, drop_da
 from ensembl.utils import StrPath
 from ensembl.utils.database.dbconnection import DBConnection, StrURL
 
+TEST_USERNAME = os.environ.get("USER", "pytestuser")
+
 
 class UnitTestDB:
     """Creates and connects to a new test database, applying the schema and importing the data.
@@ -84,7 +86,7 @@ class UnitTestDB:
         db_url = make_url(server_url)
         if not name:
             name = Path(dump_dir).name if dump_dir else "testdb"
-        db_name = os.environ["USER"] + "_" + name
+        db_name =  f"{TEST_USERNAME}_{name}"
 
         # Add the database name to the URL
         if db_url.get_dialect().name == "sqlite":

--- a/tests/database/test_dbconnection.py
+++ b/tests/database/test_dbconnection.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Unit testing of `ensembl.utils.database.dbconnection` module."""
 
-import os
 from pathlib import Path
 
 import pytest
@@ -28,9 +27,6 @@ from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from ensembl.utils.database import DBConnection, UnitTestDB
 from ensembl.utils.database.unittestdb import TEST_USERNAME
-
-
-USERNAME = os.environ.get("USER", TEST_USERNAME)
 
 
 class MockBase(DeclarativeBase):
@@ -88,7 +84,7 @@ class TestDBConnection:
     @pytest.mark.dependency(name="test_db_name", depends=["test_init", "test_dialect"], scope="class")
     def test_db_name(self) -> None:
         """Tests `DBConnection.db_name` property."""
-        expected_db_name = f"{USERNAME}_mock_db"
+        expected_db_name = f"{TEST_USERNAME}_mock_db"
         if self.dbc.dialect == "sqlite":
             expected_db_name += ".db"
         assert self.dbc.db_name == expected_db_name
@@ -264,7 +260,7 @@ def test_create_all_tables(request: FixtureRequest) -> None:
 
     # Create a test db
     db_url = make_url(request.config.getoption("server"))
-    db_name = f"{USERNAME}_test_create_all_tables"
+    db_name = f"{TEST_USERNAME}_test_create_all_tables"
     db_url = db_url.set(database=db_name)
     if database_exists(db_url):
         drop_database(db_url)
@@ -283,7 +279,7 @@ def test_create_table(request: FixtureRequest) -> None:
 
     # Create a test db
     db_url = make_url(request.config.getoption("server"))
-    db_name = f"{USERNAME}_test_create_table"
+    db_name = f"{TEST_USERNAME}_test_create_table"
     db_url = db_url.set(database=db_name)
     if database_exists(db_url):
         drop_database(db_url)

--- a/tests/database/test_dbconnection.py
+++ b/tests/database/test_dbconnection.py
@@ -27,6 +27,10 @@ from sqlalchemy.ext.automap import automap_base
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from ensembl.utils.database import DBConnection, UnitTestDB
+from ensembl.utils.database.unittestdb import TEST_USERNAME
+
+
+USERNAME = os.environ.get("USER", TEST_USERNAME)
 
 
 class MockBase(DeclarativeBase):
@@ -84,7 +88,7 @@ class TestDBConnection:
     @pytest.mark.dependency(name="test_db_name", depends=["test_init", "test_dialect"], scope="class")
     def test_db_name(self) -> None:
         """Tests `DBConnection.db_name` property."""
-        expected_db_name = f"{os.environ['USER']}_mock_db"
+        expected_db_name = f"{USERNAME}_mock_db"
         if self.dbc.dialect == "sqlite":
             expected_db_name += ".db"
         assert self.dbc.db_name == expected_db_name
@@ -260,7 +264,7 @@ def test_create_all_tables(request: FixtureRequest) -> None:
 
     # Create a test db
     db_url = make_url(request.config.getoption("server"))
-    db_name = f"{os.environ['USER']}_test_create_all_tables"
+    db_name = f"{USERNAME}_test_create_all_tables"
     db_url = db_url.set(database=db_name)
     if database_exists(db_url):
         drop_database(db_url)
@@ -279,7 +283,7 @@ def test_create_table(request: FixtureRequest) -> None:
 
     # Create a test db
     db_url = make_url(request.config.getoption("server"))
-    db_name = f"{os.environ['USER']}_test_create_table"
+    db_name = f"{USERNAME}_test_create_table"
     db_url = db_url.set(database=db_name)
     if database_exists(db_url):
         drop_database(db_url)


### PR DESCRIPTION
Fix for pytest failing in genomio CICD because its test environment doesn't have `USER` defined.
