### PR TITLE
Add numeric argument option for the ArgumentParser class

### DIFF
--- a/src/ensembl/utils/__init__.py
+++ b/src/ensembl/utils/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Ensembl Python general-purpose utils library."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     "StrPath",

--- a/src/ensembl/utils/argparse.py
+++ b/src/ensembl/utils/argparse.py
@@ -48,6 +48,7 @@ from ensembl.utils import StrPath
 class ArgumentError(Exception):
     """An error from creating an argument (optional or positional)."""
 
+
 class ArgumentParser(argparse.ArgumentParser):
     """Extends `argparse.ArgumentParser` with additional methods and functionality.
 

--- a/tests/argparse/test_argparse.py
+++ b/tests/argparse/test_argparse.py
@@ -199,7 +199,7 @@ class TestArgumentParser:
         value_type: Callable[[str], int | float],
         min_value: int | float | None,
         max_value: int | float | None,
-        expectation: ContextManager
+        expectation: ContextManager,
     ) -> None:
         """Tests `ArgumentParser.add_numeric_argument()` method.
 

--- a/tests/argparse/test_argparse.py
+++ b/tests/argparse/test_argparse.py
@@ -186,6 +186,7 @@ class TestArgumentParser:
         "value, value_type, min_value, max_value, expectation",
         [
             param("3", int, None, None, does_not_raise(), id="Value has expected type"),
+            param("3", int, 3, 3, does_not_raise(), id="Value equal to minimum and maximum values"),
             param("3.5", float, 3.4, 3.6, does_not_raise(), id="Value within range"),
             param("3", int, 3, 2, raises(ArgumentError), id="Minimum value greater than maximum value"),
             param("3.2", int, None, None, raises(SystemExit), id="Value has incorrect type"),


### PR DESCRIPTION
@vsitnik has flagged a lack in the utility of `argparse` since numeric values cannot be checked against a range (without creating a huge collection), and this is also the case for our `ArgumentParser` class. I have now added the method `add_numeric_argument()` that not only checks the argument's type, but also that it is within an specified range.

In the process I have realised we did not include the exception class like `argparse.ArgumentError`, so I have created a simplified version of it to raise it during the addition of arguments to the parser if something goes wrong.

Unit test has been expanded to also include this new method, preserving the previous coverage of this module.