### PR TITLE
Require type hints in all methods and functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ docstring-code-format = true
 
 [tool.mypy]
 mypy_path = "src/ensembl"
+disallow_untyped_defs = true
 explicit_package_bases = true
 ignore_missing_imports = true
 show_error_codes = true

--- a/src/ensembl/utils/argparse.py
+++ b/src/ensembl/utils/argparse.py
@@ -38,7 +38,7 @@ __all__ = [
 import argparse
 import os
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 from sqlalchemy.engine import make_url, URL
 
@@ -57,7 +57,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Extends the base class to include the information about default argument values by default."""
         super().__init__(*args, **kwargs)
         self.formatter_class = argparse.ArgumentDefaultsHelpFormatter
@@ -129,7 +129,7 @@ class ArgumentParser(argparse.ArgumentParser):
             self.error(f"{value} is greater than maximum value ({max_value})")
         return result
 
-    def add_argument(self, *args, **kwargs) -> None:  # type: ignore[override]
+    def add_argument(self, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
         """Extends the parent function by excluding the default value in the help text when not provided.
 
         Only applied to required arguments without a default value, i.e. positional arguments or optional
@@ -140,7 +140,7 @@ class ArgumentParser(argparse.ArgumentParser):
             kwargs.setdefault("default", argparse.SUPPRESS)
         super().add_argument(*args, **kwargs)
 
-    def add_argument_src_path(self, *args, **kwargs) -> None:
+    def add_argument_src_path(self, *args: Any, **kwargs: Any) -> None:
         """Adds `pathlib.Path` argument, checking if it exists and it is readable at parsing time.
 
         If "metavar" is not defined, it is added with "PATH" as value to improve help text readability.
@@ -150,7 +150,7 @@ class ArgumentParser(argparse.ArgumentParser):
         kwargs["type"] = self._validate_src_path
         self.add_argument(*args, **kwargs)
 
-    def add_argument_dst_path(self, *args, exists_ok: bool = True, **kwargs) -> None:
+    def add_argument_dst_path(self, *args: Any, exists_ok: bool = True, **kwargs: Any) -> None:
         """Adds `pathlib.Path` argument, checking if it is writable at parsing time.
 
         If "metavar" is not defined it is added with "PATH" as value to improve help text readability.
@@ -163,7 +163,7 @@ class ArgumentParser(argparse.ArgumentParser):
         kwargs["type"] = lambda x: self._validate_dst_path(x, exists_ok)
         self.add_argument(*args, **kwargs)
 
-    def add_argument_url(self, *args, **kwargs) -> None:
+    def add_argument_url(self, *args: Any, **kwargs: Any) -> None:
         """Adds `sqlalchemy.engine.URL` argument.
 
         If "metavar" is not defined it is added with "URI" as value to improve help text readability.
@@ -176,11 +176,11 @@ class ArgumentParser(argparse.ArgumentParser):
     # pylint: disable=redefined-builtin
     def add_numeric_argument(
         self,
-        *args,
+        *args: Any,
         type: Callable[[str], int | float] = float,
         min_value: int | float | None = None,
         max_value: int | float | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Adds a numeric argument with constrains on its type and its minimum or maximum value.
 
@@ -284,7 +284,7 @@ class ArgumentParser(argparse.ArgumentParser):
                 help="level of the events to track in the log file: %(choices)s",
             )
 
-    def parse_args(self, *args, **kwargs) -> argparse.Namespace:  # type: ignore[override]
+    def parse_args(self, *args: Any, **kwargs: Any) -> argparse.Namespace:  # type: ignore[override]
         """Extends the parent function by adding a new URL argument for every server group added.
 
         The type of this new argument will be `sqlalchemy.engine.URL`. It also logs all the parsed

--- a/src/ensembl/utils/database/dbconnection.py
+++ b/src/ensembl/utils/database/dbconnection.py
@@ -157,9 +157,9 @@ class DBConnection:
 
         @event.listens_for(engine, "connect")
         def do_connect(
-            dbapi_connection: sqlalchemy.engine.interfaces.DBAPIConnection,
-            connection_record: sqlalchemy.pool.ConnectionPoolEntry,
-        ) -> None:  # pylint: disable=unused-argument
+            dbapi_connection: Any,  # SQLAlchemy is not clear about the type of this argument
+            connection_record: sqlalchemy.pool.ConnectionPoolEntry,  # pylint: disable=unused-argument
+        ) -> None:
             """Disables emitting the BEGIN statement entirely, as well as COMMIT before any DDL."""
             dbapi_connection.isolation_level = None
 
@@ -223,8 +223,9 @@ class DBConnection:
             # Define a new transaction event
             @event.listens_for(session, "after_transaction_end")
             def end_savepoint(
-                session: sqlalchemy.orm.Session, transaction: sqlalchemy.orm.SessionTransaction
-            ) -> None:  # pylint: disable=unused-argument
+                session: sqlalchemy.orm.Session,  # pylint: disable=unused-argument
+                transaction: sqlalchemy.orm.SessionTransaction,  # pylint: disable=unused-argument
+            ) -> None:
                 if not connection.in_nested_transaction():
                     connection.begin_nested()
 

--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -42,6 +42,7 @@ __all__ = [
 import os
 from pathlib import Path
 import subprocess
+from typing import Any
 
 import sqlalchemy
 from sqlalchemy import text
@@ -172,8 +173,8 @@ class UnitTestDB:
         else:
             conn.execute(text(f"LOAD DATA LOCAL INFILE '{src}' INTO TABLE {table}"))
 
-    def __enter__(self):
+    def __enter__(self) -> UnitTestDB:
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> None:
         self.drop()

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -30,7 +30,7 @@ from ensembl.utils.archive import open_gz_file, extract_file
         param("sample.txt", "sample.txt", id="uncompressed file"),
     ],
 )
-def test_open_gz_file(data_dir, src_file, expected_file) -> None:
+def test_open_gz_file(data_dir: Path, src_file: str, expected_file: str) -> None:
     """Tests `open_gz_file()` function.
 
     Args:

--- a/tests/rloader/test_rloader.py
+++ b/tests/rloader/test_rloader.py
@@ -35,7 +35,9 @@ class MockResponse:
     status_code: int = 200
 
 
-def mock_requests_get(file_path: Path, *args, **kwargs) -> MockResponse:  # pylint: disable=unused-argument
+def mock_requests_get(
+    file_path: Path, *args: Any, **kwargs: Any
+) -> MockResponse:  # pylint: disable=unused-argument
     """Mocks `requests.get()` function, bypassing the required internet connection."""
     with file_path.open("r") as in_file:
         content = in_file.read()

--- a/tests/rloader/test_rloader.py
+++ b/tests/rloader/test_rloader.py
@@ -36,8 +36,8 @@ class MockResponse:
 
 
 def mock_requests_get(
-    file_path: Path, *args: Any, **kwargs: Any
-) -> MockResponse:  # pylint: disable=unused-argument
+    file_path: Path, *args: Any, **kwargs: Any  # pylint: disable=unused-argument
+) -> MockResponse:
     """Mocks `requests.get()` function, bypassing the required internet connection."""
     with file_path.open("r") as in_file:
         content = in_file.read()


### PR DESCRIPTION
I have added a new flag for `mypy` to ensure every method and function has type hints. It has flagged quite a few parts of the code that was missing type hints, so these have been resolved.

It may not be a bad idea to request this flag in all Ensembl repositories...