### PR TITLE
Actually add the use of metadata to build unittestdb

### DIFF
--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -118,6 +118,7 @@ class UnitTestDB:
     def _load_schema_and_data(
         self, dump_dir: StrPath | None = None, metadata: MetaData | None = None
     ) -> None:
+
         with self.dbc.begin() as conn:
             # Set InnoDB engine as default and disable foreign key checks for MySQL databases
             if self.dbc.dialect == "mysql":

--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -118,7 +118,6 @@ class UnitTestDB:
     def _load_schema_and_data(
         self, dump_dir: StrPath | None = None, metadata: MetaData | None = None
     ) -> None:
-
         with self.dbc.begin() as conn:
             # Set InnoDB engine as default and disable foreign key checks for MySQL databases
             if self.dbc.dialect == "mysql":

--- a/src/ensembl/utils/plugin.py
+++ b/src/ensembl/utils/plugin.py
@@ -24,6 +24,7 @@ from typing import Callable, Generator
 
 import pytest
 from pytest import Config, FixtureRequest, Parser
+from sqlalchemy.schema import MetaData
 
 from ensembl.utils import StrPath
 from ensembl.utils.database import UnitTestDB
@@ -125,7 +126,9 @@ def fixture_db_factory(request: FixtureRequest, data_dir: Path) -> Generator[Cal
     created: dict[str, UnitTestDB] = {}
     server_url = request.config.getoption("server")
 
-    def _db_factory(src: StrPath | None, name: str | None = None) -> UnitTestDB:
+    def _db_factory(
+        src: StrPath | None, name: str | None = None, metadata: MetaData | None = None
+    ) -> UnitTestDB:
         """Returns a unit test database.
 
         Args:
@@ -142,7 +145,9 @@ def fixture_db_factory(request: FixtureRequest, data_dir: Path) -> Generator[Cal
         else:
             db_key = name if name else "dbkey"
             dump_dir = None
-        return created.setdefault(db_key, UnitTestDB(server_url, dump_dir=dump_dir, name=name))
+        return created.setdefault(
+            db_key, UnitTestDB(server_url, dump_dir=dump_dir, name=name, metadata=metadata)
+        )
 
     yield _db_factory
     # Drop all unit test databases unless the user has requested to keep them
@@ -175,5 +180,5 @@ def test_dbs(request: FixtureRequest, db_factory: Callable) -> dict[str, UnitTes
         src = Path(argument["src"])
         name = argument.get("name", None)
         key = name if name else src.name
-        databases[key] = db_factory(src=src, name=name)
+        databases[key] = db_factory(src=src, name=name, metadata=argument.get("metadata"))
     return databases

--- a/src/ensembl/utils/plugin.py
+++ b/src/ensembl/utils/plugin.py
@@ -134,6 +134,7 @@ def fixture_db_factory(request: FixtureRequest, data_dir: Path) -> Generator[Cal
         Args:
             src: Directory path where the test database schema and content files are located, if any.
             name: Name to give to the new database. See `UnitTestDB` for more information.
+            metadata: SQLAlchemy ORM schema to populate the schema of the test database.
 
         """
         if src is not None:

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -23,8 +23,8 @@ from typing import Callable, ContextManager
 
 import pytest
 from pytest import FixtureRequest, param, raises
-from sqlalchemy.schema import MetaData
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.schema import MetaData
 
 from ensembl.utils.database import UnitTestDB
 
@@ -88,7 +88,7 @@ def test_assert_files(
 )
 def test_db_factory(
     request: FixtureRequest,
-    db_factory: Callable[[Path, str, MetaData | None], UnitTestDB],
+    db_factory: Callable[[Path | None, str | None, MetaData | None], UnitTestDB],
     data_dir: Path,
     dump_dir: Path,
     make_absolute: bool,


### PR DESCRIPTION
UnitTestDB can be created from a metadata (SQLAlchemy ORM), so this allows the plugin to use that feature.
