### PR TITLE
Bugfix: do not rely on self to store knowledge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ disable = [
     "too-few-public-methods",
     "too-many-arguments",
     "too-many-locals",
+    "too-many-positional-arguments",
     "too-many-statements",
     "unspecified-encoding",
     "wildcard-import",

--- a/src/ensembl/utils/__init__.py
+++ b/src/ensembl/utils/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Ensembl Python general-purpose utils library."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = [
     "StrPath",


### PR DESCRIPTION
`self` changes when the server arguments are defined at the subparser level, so all arguments are parsed correctly but the list of server groups is lost, so no URL argument was being generated when using subparsers. The fix is to extract from the list of arguments those that may look like a host to build the URLs.