### PR TITLE
Expand credentials env var in UnitTestDB constructor

### DIFF
--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -114,12 +114,8 @@ class UnitTestDB:
             ):
                 # If access denied, assume that the password is an environment
                 # variable, and try again with that variable expanded.
-                updated_credential = os.path.expandvars(db_url.password)
-                if updated_credential:
-                    db_url = db_url.set(password=updated_credential)
-                    db_exists = database_exists(db_url)
-                else:
-                    raise
+                db_url = db_url.set(password=os.path.expandvars(db_url.password))
+                db_exists = database_exists(db_url)
             else:
                 raise
         if db_exists:

--- a/src/ensembl/utils/database/unittestdb.py
+++ b/src/ensembl/utils/database/unittestdb.py
@@ -106,9 +106,12 @@ class UnitTestDB:
         try:
             db_exists = database_exists(db_url)
         except OperationalError as exc:
-            if (exc.code == "e3q8"  # OperationalError ... https://sqlalche.me/e/20/e3q8
-                    and exc.orig and exc.orig.args[0] == 1045  # Access denied
-                    and db_url.password):
+            if (
+                exc.code == "e3q8"  # OperationalError ... https://sqlalche.me/e/20/e3q8
+                and exc.orig
+                and exc.orig.args[0] == 1045  # Access denied
+                and db_url.password
+            ):
                 # If access denied, assume that the password is an environment
                 # variable, and try again with that variable expanded.
                 updated_credential = os.path.expandvars(db_url.password)


### PR DESCRIPTION
If an Access Denied error (`1045`) occurs when accessing a MySQL test database in the `UnitTestDB` constructor, this PR would catch the exception and, on the assumption that the given credential is the name of an environment variable, attempt to expand the environment variable and retry with the expanded variable as the new credential.

This does not change the default behaviour, so other cases (e.g. `SQLite`, mocked test databases) should be unaffected. 