### PR TITLE
Reintroduce pytest_configure() hook to parse env vars in server URL

### DIFF
--- a/src/ensembl/utils/plugin.py
+++ b/src/ensembl/utils/plugin.py
@@ -78,7 +78,7 @@ def pytest_configure(config: Config) -> None:
     # If password set, treat it as an environment variable that needs to be resolved
     if server_url.password:
         server_url = server_url.set(password=os.path.expandvars(server_url.password))
-        config.option.server = str(server_url)
+        config.option.server = server_url.render_as_string(hide_password=False)
 
 
 def pytest_report_header(config: Config) -> str:

--- a/src/ensembl/utils/plugin.py
+++ b/src/ensembl/utils/plugin.py
@@ -24,6 +24,7 @@ from typing import Callable, Generator, TypeAlias
 
 import pytest
 from pytest import Config, FixtureRequest, Parser
+from sqlalchemy.engine import make_url
 from sqlalchemy.schema import MetaData
 
 from ensembl.utils import StrPath
@@ -61,6 +62,23 @@ def pytest_addoption(parser: Parser) -> None:
         required=False,
         help="Do not remove the test databases (default: False)",
     )
+
+
+def pytest_configure(config: Config) -> None:
+    """Allows plugins and conftest files to perform initial configuration.
+
+    More information: https://docs.pytest.org/en/latest/reference/reference.html#std-hook-pytest_configure
+
+    Args:
+        config: The pytest config object.
+
+    """
+    # Load server information
+    server_url = make_url(config.getoption("server"))
+    # If password set, treat it as an environment variable that needs to be resolved
+    if server_url.password:
+        server_url = server_url.set(password=os.path.expandvars(server_url.password))
+        config.option.server = str(server_url)
 
 
 def pytest_report_header(config: Config) -> str:


### PR DESCRIPTION
Alternative solution to the problem presented in https://github.com/Ensembl/ensembl-utils/pull/29 that resolves the password at the configuration stage rather than every time a unit test database needs to be created (this code was present in the previous repository but was mistakenly removed due to the wrong manual tests been made).