### PR TITLE
Create PR instead of attempting a commit to a protected branch

### DIFF
--- a/.github/workflows/notice.yml
+++ b/.github/workflows/notice.yml
@@ -23,6 +23,10 @@ jobs:
   notice_update:
     name: Update NOTICE copyright year
     runs-on: ubuntu-latest
+    env:
+      branch_name: bau/notice-update
+    permissions:
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -33,5 +37,12 @@ jobs:
 
       - uses: EndBug/add-and-commit@v9
         with:
+          new_branch: ${{ env.branch_name }}
           add: 'NOTICE'
           message: 'Update NOTICE copyright year'
+
+      - name: Create pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create -B main -H $branch_name --title 'Update NOTICE copyright year' --body 'Created by GitHub action'

--- a/.github/workflows/notice.yml
+++ b/.github/workflows/notice.yml
@@ -18,6 +18,7 @@ name: "Update NOTICE copyright year at the start of every year"
 on:
   schedule:
     - cron:  '15 15 1 1 *'
+  workflow_dispatch:
 
 jobs:
   notice_update:


### PR DESCRIPTION
The scheduled GitHub action to update the NOTICE file when a new year arrives is working as expected, but the first implementation attempted to push a commit directly to a protected branch which has failed. Although it may require manual intervention, this is a safer path to attempt the same.