### PR TITLE
Upgrade archive.open_gz_file() to allow mode and encoding args

### DIFF
--- a/src/ensembl/utils/archive.py
+++ b/src/ensembl/utils/archive.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 import gzip
 from pathlib import Path
 import shutil
-from typing import Generator, TextIO
+from typing import Generator, IO
 
 from ensembl.utils import StrPath
 from ensembl.utils.argparse import ArgumentParser
@@ -54,21 +54,25 @@ SUPPORTED_ARCHIVE_FORMATS = [ext for elem in shutil.get_unpack_formats() for ext
 
 
 @contextmanager
-def open_gz_file(file_path: StrPath) -> Generator[TextIO, None, None]:
+def open_gz_file(
+    file_path: StrPath, mode: str = "rt", encoding: str = "utf-8"
+) -> Generator[gzip.GzipFile | IO, None, None]:
     """Yields an open file object, even if the file is compressed with gzip.
 
     The file is expected to contain a text, and this can be used with the usual "with".
 
     Args:
         file_path: A (single) file path to open.
+        mode: The mode in which the file is opened.
+        encoding: The name of the encoding used to decode or encode the file.
 
     """
     src_file = Path(file_path)
     if src_file.suffix == ".gz":
-        with gzip.open(src_file, "rt") as fh:
+        with gzip.open(src_file, mode, encoding=encoding) as fh:
             yield fh
     else:
-        with src_file.open("rt") as fh:
+        with src_file.open(mode, encoding=encoding) as fh:
             yield fh
 
 

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -23,6 +23,7 @@ from pytest import param
 from ensembl.utils.archive import open_gz_file, extract_file
 
 
+@pytest.mark.dependency(name="open_gz_file_read")
 @pytest.mark.parametrize(
     "src_file, expected_file",
     [
@@ -30,11 +31,10 @@ from ensembl.utils.archive import open_gz_file, extract_file
         param("sample.txt", "sample.txt", id="uncompressed file"),
     ],
 )
-def test_open_gz_file(data_dir: Path, src_file: str, expected_file: str) -> None:
-    """Tests `open_gz_file()` function.
+def test_open_gz_file_read(data_dir: Path, src_file: str, expected_file: str) -> None:
+    """Tests `open_gz_file()` function for read mode.
 
     Args:
-        tmp_path: Fixture that provides a temporary directory path unique to the test invocation.
         data_dir: Fixture that provides the path to the test data folder matching the test's name.
         src_file: Source file to open.
         expected_file: File with the expected content to be found in the source file.
@@ -48,6 +48,31 @@ def test_open_gz_file(data_dir: Path, src_file: str, expected_file: str) -> None
     with expected_path.open("r") as in_file:
         expected_content = in_file.readlines()
     assert src_content == expected_content
+
+
+@pytest.mark.dependency(depends=["open_gz_file_read"])
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        param("test.txt.gz", id="gzip file"),
+        param("test.txt", id="uncompressed file"),
+    ],
+)
+def test_open_gz_file_write(tmp_path: Path, file_name: str) -> None:
+    """Tests `open_gz_file()` function for write mode.
+
+    Args:
+        tmp_path: Fixture that provides a temporary directory path unique to the test invocation.
+        file_name: Name of the file to be created and written to.
+
+    """
+    text = "test content\n"
+    file_path = tmp_path / file_name
+    with open_gz_file(file_path, mode="wt") as out_file:
+        out_file.write(text)
+    # Check if the content has been written correctly
+    with open_gz_file(file_path) as in_file:
+        assert text == "".join(in_file.readlines())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It preserves backwards compatibility whilst allowing people to open archives in write mode or in a different encoding.

The unit test has been updated accordingly.